### PR TITLE
Print JSONPath in error messages

### DIFF
--- a/json-directory.cabal
+++ b/json-directory.cabal
@@ -22,7 +22,7 @@ source-repository head
 library
   exposed-modules:
     Data.JSON.Directory
-  build-depends:       base ^>=4.12.0.0, aeson, directory, filepath, text, unordered-containers
+  build-depends:       base ^>=4.12.0.0, aeson, bytestring, directory, filepath, text, unordered-containers
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
This seems to be what it takes to get error messages that include the `JSONPath`. The bad news is that I had to use quite a few of the internal parts of aeson, up to you if that's acceptable for this library.

Here are the differences in error messages for the two classes of errors:

1. Failure to decode a file as a `Value` (i.e. invalid JSON)
```diff
-Error in $: ',' or '}': not enough input
+Error in $.dir.subdir.file: ',' or '}': not enough input
```

2. Failure to parse the `Value`
```diff
-expected String, but encountered Number
+Error in $.dir.subdir.file.key: expected String, but encountered Number
```